### PR TITLE
Update libQtShadowsocks-2.1.0.ebuild

### DIFF
--- a/net-proxy/libQtShadowsocks/libQtShadowsocks-2.1.0.ebuild
+++ b/net-proxy/libQtShadowsocks/libQtShadowsocks-2.1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=5
 inherit cmake-utils
 
 MY_PV=${PV/_beta/beta}


### PR DESCRIPTION
you declared EAPI = 5 in file "enviroment".(you will found it in "/var/tmp/portage/net-proxy/libQtShadowsocks/temp" when you are emering this software)